### PR TITLE
Use airbnb-config v2.1

### DIFF
--- a/linters/eslint-config-groupon/base.js
+++ b/linters/eslint-config-groupon/base.js
@@ -30,8 +30,7 @@ module.exports = {
     // not relative to our package.
     // We use require.resolve to get absolute paths which will
     // always point to the right place.
-    require.resolve('./legacy'),
-    require.resolve('eslint-config-airbnb/rules/es6'),
+    require.resolve('eslint-config-airbnb/base'),
   ],
   // eslint's own parser doesn't support async functions
   parser: require.resolve('babel-eslint')

--- a/linters/eslint-config-groupon/index.js
+++ b/linters/eslint-config-groupon/index.js
@@ -30,8 +30,7 @@ module.exports = {
     // not relative to our package.
     // We use require.resolve to get absolute paths which will
     // always point to the right place.
-    require.resolve('./base'),
-    require.resolve('eslint-config-airbnb/rules/react'),
+    require.resolve('eslint-config-airbnb'),
   ],
   // eslint's own parser doesn't support async functions
   parser: require.resolve('babel-eslint')

--- a/linters/eslint-config-groupon/legacy.js
+++ b/linters/eslint-config-groupon/legacy.js
@@ -30,26 +30,11 @@ module.exports = {
     // not relative to our package.
     // We use require.resolve to get absolute paths which will
     // always point to the right place.
-    require.resolve('eslint-config-airbnb/rules/best-practices'),
-    require.resolve('eslint-config-airbnb/rules/errors'),
-    require.resolve('eslint-config-airbnb/rules/legacy'),
-    require.resolve('eslint-config-airbnb/rules/node'),
-    require.resolve('eslint-config-airbnb/rules/strict'),
-    require.resolve('eslint-config-airbnb/rules/style'),
-    require.resolve('eslint-config-airbnb/rules/variables')
+    require.resolve('eslint-config-airbnb/legacy'),
   ],
-  'env': {
-    'browser': true,
-    'node': true,
-    'amd': false,
-    'mocha': false,
-    'jasmine': false
-  },
-  'ecmaFeatures': {},
-  'globals': {},
   'rules': {
     'vars-on-top': 0,
-    'strict': [ 2, 'global' ],
+    'strict': [2, 'global'],
     'no-param-reassign': 0,
   }
 };

--- a/linters/eslint-config-groupon/package.json
+++ b/linters/eslint-config-groupon/package.json
@@ -26,7 +26,7 @@
   "license": "BSD-3-Clause",
   "dependencies": {
     "babel-eslint": "^4.1.5",
-    "eslint-config-airbnb": "^1.0.0"
+    "eslint-config-airbnb": "^2.1.0"
   },
   "bugs": {
     "url": "https://github.com/groupon/javascript/issues"


### PR DESCRIPTION
v2.1.0 contains https://github.com/airbnb/javascript/pull/582 which means we can remove most of the hacks. There are some changes to `[]` and `{}` spacing which means we'll have to bump to v2.0.0. But it looked like just running `eslint --fix` is enough to migrate projects.