### PR TITLE
Add node 6.x code style

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,3 @@
 language: node_js
 node_js:
   - '4'
-install:
-  - 'cd linters/eslint-config-groupon && npm install'
-script:
-  - 'npm test'

--- a/README.md
+++ b/README.md
@@ -45,6 +45,20 @@ There is no difference between the airbnb and the Groupon rules for anything but
 
 #### Generally
 
+##### `no-underscore-dangle`
+
+Opinions on what "private state" means and how to use it vary.
+The [Airbnb guide](https://github.com/airbnb/javascript#naming--leading-underscore) comes down on the side of "if something can be inspected, it's not truly private".
+We explicitly allow and even encourage the use of underscored properties for private state.
+
+1. It's hard to define "can be inspected" in JavaScript, especially in node (there's always `vm.runInDebugContext`).
+2. There's immense value in having private state inspectable while debugging certain issues.
+
+We trust that users of libraries are aware that underscored properties are never part of the official interface
+and changes to underscored properties are not considered breaking changes.
+
+Using underscored properties outside of methods (e.g. not on `this`) is still considered an error.
+
 ##### Short Identifiers
 
 The airbnb config allows identifiers of any length.

--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ into a separate library without polluting unrelated pieces of logic.
 For client-side code using ES2015 and [proposed upcoming features](https://github.com/tc39/ecma262#ecmascript) like object spread is encouraged.
 The default lint style should be `groupon` or `groupon-react` when using React.
 
-For server-side code running on node 4 or higher,
+For server-side code running on node 4.x/6.x or higher,
 we try to restrict ourselves to the features that are natively supported.
 This simplifies tooling and improves startup times.
-The default lint style should be `groupon-node4`.
+The default lint style should be `groupon-node4`/`groupon-node6`.
 
 ### Versioning and Publishing
 

--- a/linters/eslint-config-groupon-es5/index.js
+++ b/linters/eslint-config-groupon-es5/index.js
@@ -33,8 +33,9 @@ module.exports = {
     require.resolve('eslint-config-airbnb-base/legacy'),
   ],
   'rules': {
-    'vars-on-top': 0,
-    'strict': [2, 'global'],
     'no-param-reassign': 0,
+    'no-underscore-dangle': [2, { allowAfterThis: true }],
+    'strict': [2, 'global'],
+    'vars-on-top': 0,
   },
 };

--- a/linters/eslint-config-groupon-es5/package.json
+++ b/linters/eslint-config-groupon-es5/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-groupon-es5",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "ESLint configuration, groupon-style",
   "main": "index.js",
   "files": [

--- a/linters/eslint-config-groupon-node4/index.js
+++ b/linters/eslint-config-groupon-node4/index.js
@@ -42,8 +42,9 @@ module.exports = {
     },
   },
   rules: {
-    'node/no-unsupported-features': [2, {version: 4}],
+    'node/no-unsupported-features': [2, { version: 4 }],
     'no-param-reassign': 0,
+    'no-underscore-dangle': [2, { allowAfterThis: true }],
     strict: [2, 'global'],
   }
 };

--- a/linters/eslint-config-groupon-node4/package.json
+++ b/linters/eslint-config-groupon-node4/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-groupon-node4",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "ESLint configuration, groupon-style",
   "main": "index.js",
   "files": [

--- a/linters/eslint-config-groupon-node6/LICENSE
+++ b/linters/eslint-config-groupon-node6/LICENSE
@@ -1,0 +1,29 @@
+Copyright (c) 2015, Groupon, Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+
+Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+Neither the name of GROUPON nor the names of its contributors may be
+used to endorse or promote products derived from this software without
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/linters/eslint-config-groupon-node6/README.md
+++ b/linters/eslint-config-groupon-node6/README.md
@@ -1,0 +1,8 @@
+# Groupon ESLint Styles for node 6.x
+
+Groupon's coding guidelines for code that runs natively on node 6+.
+This should only be used for app-level code
+or code that is certain to never be used in a browser environment.
+
+This is a thin wrapper around [eslint-config-airbnb](https://www.npmjs.com/package/eslint-config-airbnb).
+More info can be found at [groupon/javascript](https://github.com/groupon/javascript).

--- a/linters/eslint-config-groupon-node6/index.js
+++ b/linters/eslint-config-groupon-node6/index.js
@@ -1,0 +1,49 @@
+/*
+Copyright (c) 2014, Groupon, Inc.
+All rights reserved.
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+Neither the name of GROUPON nor the names of its contributors may be
+used to endorse or promote products derived from this software without
+specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+module.exports = {
+  extends: [
+    // ESLint will resolve all references relative to the app,
+    // not relative to our package.
+    // We use require.resolve to get absolute paths which will
+    // always point to the right place.
+    require.resolve('eslint-config-airbnb-base'),
+  ],
+  plugins: [
+    'node',
+  ],
+  parserOptions: {
+    sourceType: 'script',
+    ecmaFeatures: {
+      generators: true,
+    },
+  },
+  rules: {
+    'node/no-unsupported-features': [2, { version: 6 }],
+    'no-underscore-dangle': [2, { allowAfterThis: true }],
+    strict: [2, 'global'],
+  }
+};

--- a/linters/eslint-config-groupon-node6/package.json
+++ b/linters/eslint-config-groupon-node6/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "eslint-config-groupon-node6",
+  "version": "3.1.0",
+  "description": "ESLint configuration, groupon-style",
+  "main": "index.js",
+  "files": [
+    "index.js"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/groupon/javascript.git"
+  },
+  "keywords": [
+    "eslint",
+    "config"
+  ],
+  "author": {
+    "name": "Jan Krems",
+    "email": "jan.krems@groupon.com"
+  },
+  "license": "BSD-3-Clause",
+  "dependencies": {
+    "eslint-config-airbnb-base": "^3.0.0"
+  },
+  "bugs": {
+    "url": "https://github.com/groupon/javascript/issues"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org"
+  },
+  "homepage": "https://github.com/groupon/javascript#readme",
+  "peerDependencies": {
+    "eslint": "^2.8.0",
+    "eslint-plugin-import": "^1.5.0",
+    "eslint-plugin-node": "^2.0.0"
+  }
+}

--- a/linters/eslint-config-groupon-react/index.js
+++ b/linters/eslint-config-groupon-react/index.js
@@ -34,4 +34,10 @@ module.exports = {
   ],
   // eslint's own parser doesn't support async functions
   parser: require.resolve('babel-eslint'),
+  'rules': {
+    'no-param-reassign': 0,
+    'no-underscore-dangle': [2, { allowAfterThis: true }],
+    'strict': [2, 'global'],
+    'vars-on-top': 0,
+  },
 };

--- a/linters/eslint-config-groupon-react/package.json
+++ b/linters/eslint-config-groupon-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-groupon-react",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "ESLint configuration, groupon-style",
   "main": "index.js",
   "files": [

--- a/linters/eslint-config-groupon/index.js
+++ b/linters/eslint-config-groupon/index.js
@@ -34,4 +34,10 @@ module.exports = {
   ],
   // eslint's own parser doesn't support async functions
   parser: require.resolve('babel-eslint'),
+  'rules': {
+    'no-param-reassign': 0,
+    'no-underscore-dangle': [2, { allowAfterThis: true }],
+    'strict': [2, 'global'],
+    'vars-on-top': 0,
+  },
 };

--- a/linters/eslint-config-groupon/package.json
+++ b/linters/eslint-config-groupon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-groupon",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "ESLint configuration, groupon-style",
   "main": "index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "groupon-styleguide",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "private": true,
   "scripts": {
     "pretest": "eslint test/valid",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "eslint-config-groupon": "file:./linters/eslint-config-groupon",
     "eslint-config-groupon-es5": "file:./linters/eslint-config-groupon-es5",
     "eslint-config-groupon-node4": "file:./linters/eslint-config-groupon-node4",
+    "eslint-config-groupon-node6": "file:./linters/eslint-config-groupon-node6",
     "eslint-config-groupon-react": "file:./linters/eslint-config-groupon-react",
     "eslint-plugin-jsx-a11y": "^1.0.2",
     "eslint-plugin-import": "^1.7.0",

--- a/test/compare-versions.test.js
+++ b/test/compare-versions.test.js
@@ -6,6 +6,7 @@ var ROOT_PKG = require('../package.json');
 var LINT_PKGS = [
   'groupon',
   'groupon-es5',
+  'groupon-node4',
   'groupon-react',
 ].map(function (linter) {
   return require('../linters/eslint-config-' + linter + '/package.json');

--- a/test/compare-versions.test.js
+++ b/test/compare-versions.test.js
@@ -7,6 +7,7 @@ var LINT_PKGS = [
   'groupon',
   'groupon-es5',
   'groupon-node4',
+  'groupon-node6',
   'groupon-react',
 ].map(function (linter) {
   return require('../linters/eslint-config-' + linter + '/package.json');

--- a/test/valid/es5/underscore-dangle.js
+++ b/test/valid/es5/underscore-dangle.js
@@ -1,0 +1,6 @@
+'use strict';
+function MyClass() {
+  this._prop = 'totally private';
+}
+// setTimeout b/c no-unused-expressions
+setTimeout(new MyClass());

--- a/test/valid/groupon/async-function.js
+++ b/test/valid/groupon/async-function.js
@@ -1,8 +1,7 @@
-// babel-eslint and eslint don't play nice for this case:
-// https://github.com/eslint/eslint/issues/4442
-//
-// async function f() {
-// }
+async function f() {
+  return true;
+}
+f(); // no unused
 
 const g = async () => true;
 g(); // no unused

--- a/test/valid/groupon/underscore-dangle.js
+++ b/test/valid/groupon/underscore-dangle.js
@@ -1,0 +1,13 @@
+function MyClass() {
+  this._prop = 'totally private';
+}
+// setTimeout b/c no-unused-expressions
+setTimeout(new MyClass());
+
+class ES6Class {
+  constructor() {
+    this._prop = 'totally private';
+  }
+}
+// setTimeout b/c no-unused-expressions
+setTimeout(new ES6Class());

--- a/test/valid/node4/underscore-dangle.js
+++ b/test/valid/node4/underscore-dangle.js
@@ -1,0 +1,14 @@
+'use strict';
+function MyClass() {
+  this._prop = 'totally private';
+}
+// setTimeout b/c no-unused-expressions
+setTimeout(new MyClass());
+
+class ES6Class {
+  constructor() {
+    this._prop = 'totally private';
+  }
+}
+// setTimeout b/c no-unused-expressions
+setTimeout(new ES6Class());

--- a/test/valid/node6/.eslintrc
+++ b/test/valid/node6/.eslintrc
@@ -1,0 +1,3 @@
+{
+  "extends": "groupon-node6"
+}

--- a/test/valid/node6/default-args.js
+++ b/test/valid/node6/default-args.js
@@ -1,0 +1,5 @@
+'use strict';
+function f(x = 20) {
+  return x;
+}
+f();

--- a/test/valid/node6/destruct.js
+++ b/test/valid/node6/destruct.js
@@ -1,0 +1,6 @@
+'use strict';
+function f() {
+  const { x, y: z } = { x: 10, y: 20 };
+  return { x, z };
+}
+f();

--- a/test/valid/node6/generator.js
+++ b/test/valid/node6/generator.js
@@ -1,0 +1,4 @@
+'use strict';
+
+function* foo() { yield 42; }
+foo();

--- a/test/valid/node6/underscore-dangle.js
+++ b/test/valid/node6/underscore-dangle.js
@@ -1,0 +1,14 @@
+'use strict';
+function MyClass() {
+  this._prop = 'totally private';
+}
+// setTimeout b/c no-unused-expressions
+setTimeout(new MyClass());
+
+class ES6Class {
+  constructor() {
+    this._prop = 'totally private';
+  }
+}
+// setTimeout b/c no-unused-expressions
+setTimeout(new ES6Class());

--- a/test/valid/react/underscore-dangle.js
+++ b/test/valid/react/underscore-dangle.js
@@ -1,0 +1,13 @@
+function MyClass() {
+  this._prop = 'totally private';
+}
+// setTimeout b/c no-unused-expressions
+setTimeout(new MyClass());
+
+class ES6Class {
+  constructor() {
+    this._prop = 'totally private';
+  }
+}
+// setTimeout b/c no-unused-expressions
+setTimeout(new ES6Class());


### PR DESCRIPTION
1. Allow `this._prop` because we have a different stance on private state.
2. Re-add one async function test case that is no longer broken.
3. Order rules alphabetically.
4. Add `groupon-node6` that allows all the features introduced in node version 6.