### PR TITLE
fix: allow `arguments` use in node4

### DIFF
--- a/linters/eslint-config-groupon-node4/index.js
+++ b/linters/eslint-config-groupon-node4/index.js
@@ -44,6 +44,7 @@ module.exports = {
   rules: {
     'node/no-unsupported-features': [2, { version: 4 }],
     'no-param-reassign': 0,
+    'prefer-rest-params': 0,
     'no-underscore-dangle': [2, { allowAfterThis: true }],
     strict: [2, 'global'],
   }

--- a/test/valid/eslint/node4/arguments.js
+++ b/test/valid/eslint/node4/arguments.js
@@ -1,0 +1,6 @@
+'use strict';
+
+function foo() {
+  return arguments.length;
+}
+foo();


### PR DESCRIPTION
There are no rest args in node4.