### PR TITLE
add browser globals to coffeelint environment

### DIFF
--- a/packages/coffeelint-config-groupon/index.js
+++ b/packages/coffeelint-config-groupon/index.js
@@ -34,10 +34,9 @@ module.exports = {
   check_scope: {
     module: 'coffeescope2',
     level: 'error',
-    environments: ['node', 'es6', 'mocha'],
+    environments: ['node', 'es6', 'mocha', 'browser'],
     overwrite: false,
-    shadow_builtins: true,
-    shadow_exceptions: ['test'],
+    shadow_exceptions: ['err', 'error'],
     hoist_local: false
   },
   coffeescript_error: {
@@ -91,7 +90,9 @@ module.exports = {
   },
   newlines_after_classes: {
     value: 1,
-    level: 'warn'
+    // change to 'warn' when
+    // https://github.com/clutchski/coffeelint/issues/518 fixed
+    level: 'ignore'
   },
   no_backticks: {
     level: 'error'

--- a/test/valid/coffeelint/groupon/frontend.coffee
+++ b/test/valid/coffeelint/groupon/frontend.coffee
@@ -1,0 +1,2 @@
+'use strict'
+window.x = 'this is ok, i guess'


### PR DESCRIPTION
This will add all these: https://github.com/sindresorhus/globals/blob/4159cd067369b8242131551beb09fafb52afc289/globals.json#L163-L777 but we'll be more consistent with the eslint configs

* add browser globals
* disable `shadow_builtins`
* allow shadowing of `err` and `error`
* disable misbehaving `newlines_after_classes`