### PR TITLE
Override airbnb comma-dangle rules

### DIFF
--- a/packages/eslint-config-groupon-node4/index.js
+++ b/packages/eslint-config-groupon-node4/index.js
@@ -47,5 +47,9 @@ module.exports = {
     'prefer-rest-params': 0,
     'no-underscore-dangle': [2, { allowAfterThis: true }],
     strict: [2, 'global'],
+    'comma-dangle': [2, {
+      arrays: 'always-multiline',
+      objects: 'always-multiline',
+     }],
   }
 };

--- a/packages/eslint-config-groupon-node6/index.js
+++ b/packages/eslint-config-groupon-node6/index.js
@@ -45,5 +45,9 @@ module.exports = {
     'node/no-unsupported-features': [2, { version: 6 }],
     'no-underscore-dangle': [2, { allowAfterThis: true }],
     strict: [2, 'global'],
+    'comma-dangle': [2, {
+      arrays: 'always-multiline',
+      objects: 'always-multiline',
+     }],
   }
 };

--- a/test/valid/eslint/node4/comma-dangle.js
+++ b/test/valid/eslint/node4/comma-dangle.js
@@ -1,0 +1,23 @@
+'use strict';
+
+function foo() { }
+
+// no comma-dangle for functions
+foo(
+  1,
+  2
+);
+
+// yes comma-dangle for arrays/objects
+foo([
+  1,
+  2,
+]);
+foo({
+  x: 1,
+  y: 2,
+});
+
+// no comma-dangle for single-line arrays
+foo([1, 2]);
+foo({ x: 1, y: 2 });

--- a/test/valid/eslint/node6/comma-dangle.js
+++ b/test/valid/eslint/node6/comma-dangle.js
@@ -1,0 +1,23 @@
+'use strict';
+
+function foo() { }
+
+// no comma-dangle for functions
+foo(
+  1,
+  2
+);
+
+// yes comma-dangle for arrays/objects
+foo([
+  1,
+  2,
+]);
+foo({
+  x: 1,
+  y: 2,
+});
+
+// no comma-dangle for single-line arrays
+foo([1, 2]);
+foo({ x: 1, y: 2 });


### PR DESCRIPTION
used only for multi-line arrays and objects, not for functions