### PR TITLE
feat: support object spread and mjs

### DIFF
--- a/examples/eslint/node8/.eslintrc.js
+++ b/examples/eslint/node8/.eslintrc.js
@@ -1,0 +1,19 @@
+'use strict';
+
+module.exports = Object.assign({
+  // Unfortunately overrides are only valid in project-level config...
+  overrides: [
+    {
+      files: ['**/*.mjs'],
+      parserOptions: {
+        sourceType: 'module',
+      },
+      rules: {
+        'node/no-unsupported-features': [2, {
+          version: 8,
+          ignores: ['modules'],
+        }],
+      },
+    },
+  ],
+}, require('../../../node8'));

--- a/examples/eslint/node8/module.mjs
+++ b/examples/eslint/node8/module.mjs
@@ -1,0 +1,5 @@
+import http from 'http';
+
+export async function foo(obj) {
+  return { ...obj, http };
+}

--- a/lib/basics.js
+++ b/lib/basics.js
@@ -43,6 +43,9 @@ module.exports = {
   parserOptions: {
     ecmaVersion: 2017,
     sourceType: 'script',
+    ecmaFeatures: {
+      experimentalObjectRestSpread: true,
+    },
   },
   plugins: ['import', 'node', 'prettier'],
 };

--- a/test/lint.test.js
+++ b/test/lint.test.js
@@ -49,7 +49,7 @@ async function validate(filename, content) {
 }
 
 describe(`Linting using ESLint`, () => {
-  const files = globby.sync(`examples/**/*.js`, {
+  const files = globby.sync(`examples/**/*.{mjs,js}`, {
     ignore: 'examples/node_modules/**/*.*',
   });
 


### PR DESCRIPTION
This assumes that all ES6 modules are using `.mjs` and uses that information to switch the parse/lint mode.