### PR TITLE
add mocha lint checks

### DIFF
--- a/es5.js
+++ b/es5.js
@@ -45,7 +45,7 @@ module.exports = Object.assign({
     ecmaVersion: 5,
     sourceType: 'script',
   },
-  plugins: ['import', 'node', 'prettier'],
+  plugins: ['import', 'mocha', 'node', 'prettier'],
   rules: Object.assign({}, opinions, conventions, mistakes, {
     // Additional opinions
 

--- a/examples/eslint/node6/mocha.js
+++ b/examples/eslint/node6/mocha.js
@@ -1,0 +1,13 @@
+'use strict';
+
+/* eslint-env mocha */
+
+describe('various mocha mistakes', () => {
+  // no-exclusive-tests
+  it.only('does thing', done => {
+    it('tries to nest a test'); // no-nested-tests
+    return done; // no-return-and-callback, handle-done-callback
+  });
+
+  it('does thing'); // no-identical-title
+});

--- a/examples/eslint/node6/mocha.js.json
+++ b/examples/eslint/node6/mocha.js.json
@@ -1,0 +1,1 @@
+{ "errorCount": 4 }

--- a/lib/basics.js
+++ b/lib/basics.js
@@ -47,5 +47,5 @@ module.exports = {
       experimentalObjectRestSpread: true,
     },
   },
-  plugins: ['import', 'node', 'prettier'],
+  plugins: ['import', 'mocha', 'node', 'prettier'],
 };

--- a/lib/rules/conventions.js
+++ b/lib/rules/conventions.js
@@ -74,4 +74,7 @@ module.exports = {
 
   // See: https://eslint.org/docs/rules/prefer-arrow-callback
   'prefer-arrow-callback': 'error',
+
+  // See: https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-identical-title.md
+  'mocha/no-identical-title': 'warn',
 };

--- a/lib/rules/mistakes.js
+++ b/lib/rules/mistakes.js
@@ -177,4 +177,15 @@ module.exports = {
   ],
   // See: https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-duplicates.md
   'import/no-duplicates': 'error',
+
+  // # Mocha
+
+  // See: https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/handle-done-callback.md
+  'mocha/handle-done-callback': 'error',
+  // See: https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-exclusive-tests.md
+  'mocha/no-exclusive-tests': 'error',
+  // See: https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-tested-tests.md
+  'mocha/no-nested-tests': 'error',
+  // See: https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-return-and-callback.md
+  'mocha/no-return-and-callback': 'error',
 };

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "peerDependencies": {
     "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-mocha": "^4.12.1",
     "eslint-plugin-node": "^5.1.1",
     "eslint-plugin-prettier": "^2.2.0",
     "eslint": "^4.5.0"
@@ -35,6 +36,7 @@
     "assertive": "^2.1.0",
     "eslint": "^4.7.1",
     "eslint-plugin-import": "^2.8.0",
+    "eslint-plugin-mocha": "^4.12.1",
     "eslint-plugin-node": "^5.1.1",
     "eslint-plugin-prettier": "^2.2.0",
     "globby": "^6.1.0",


### PR DESCRIPTION
Uses eslint-plugin-mocha 4.x instead of 5.x to maintain node 4.x compatibility

BREAKING CHANGE: adds eslint-plugin-mocha as a peerDep