### PR TITLE
consistent-return: allow implicit undefined

### DIFF
--- a/examples/eslint/es5/consistent-return.js
+++ b/examples/eslint/es5/consistent-return.js
@@ -3,3 +3,7 @@
 (function x() {
   if (Math.random()) return true;
 })();
+
+(function y() {
+  if (Math.random()) return void true;
+})();

--- a/lib/rules/mistakes.js
+++ b/lib/rules/mistakes.js
@@ -140,7 +140,7 @@ module.exports = {
   'no-ex-assign': 'error',
 
   // See: https://eslint.org/docs/rules/consistent-return
-  'consistent-return': 'error',
+  'consistent-return': ['error', { treatUndefinedAsUnspecified: true }],
 
   // # Dependencies & Imports
 


### PR DESCRIPTION
Re: the concern about callbacks: now you can do:
```js
if (err) return void cb(err);
```
sort of stuff
