### PR TITLE
feat: change no-empty rule to allow empty catch()

### DIFF
--- a/lib/rules/mistakes.js
+++ b/lib/rules/mistakes.js
@@ -62,8 +62,6 @@ module.exports = {
 
   // See: https://eslint.org/docs/rules/no-debugger
   'no-debugger': 'error',
-  // See: https://eslint.org/docs/rules/no-empty
-  'no-empty': 'error',
   // See: https://eslint.org/docs/rules/no-template-curly-in-string
   'no-template-curly-in-string': 'error',
   // See: https://eslint.org/docs/rules/no-unreachable

--- a/lib/rules/opinions.js
+++ b/lib/rules/opinions.js
@@ -59,4 +59,7 @@ module.exports = {
 
   // See: https://eslint.org/docs/rules/object-shorthand
   'object-shorthand': 'error',
+
+  // See: https://eslint.org/docs/rules/no-empty
+  'no-empty': [1, { allowEmptyCatch: true }],
 };


### PR DESCRIPTION
There are cases when you use try catch like wrapping `JSON.parse` where you not essentially need to throw inside the `catch` statement.