### PR TITLE
make peerDependencies looser

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,10 +25,10 @@
     }
   },
   "peerDependencies": {
-    "eslint-plugin-import": "^2.8.0",
-    "eslint-plugin-mocha": "^5.1.0",
-    "eslint-plugin-node": "^8.0.1",
-    "eslint-plugin-prettier": "^2.6.2",
+    "eslint-plugin-import": ">=2.8.0",
+    "eslint-plugin-mocha": ">=5.1.0",
+    "eslint-plugin-node": ">=8.0.1",
+    "eslint-plugin-prettier": ">=2.6.2",
     "eslint": "^5.1.0"
   },
   "dependencies": {},


### PR DESCRIPTION
* PRO: don't have to track every major version change
* PRO: breaking changes in deps for reasons like node support we don't
    care about won't make peerDeps complain
* CON: breaking changes in deps for API changes are important, but we
    can always refine the peerDep as we come across one of those

eslint itself's breaking changes seem important

---
_This PR was started by: [git wf pr](https://github.com/groupon/git-workflow/releases/tag/v1.0.3)_