### PR TITLE
turn off node shebang test

### DIFF
--- a/lib/rules/mistakes.js
+++ b/lib/rules/mistakes.js
@@ -147,9 +147,13 @@ module.exports = {
   // See: https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-unresolved.md
   'import/no-unresolved': ['error', { commonjs: true, caseSensitive: true }],
 
-  // This does the same thing, but doesn't know about devDeps properly
+  // Doesn't know about devDeps properly
   // See: https://github.com/mysticatea/eslint-plugin-node/blob/master/docs/rules/no-unpublished-require.md
-  'node/no-unpublished-require': ['off'],
+  'node/no-unpublished-require': 'off',
+
+  // Doesn't allow for ./scripts/blah
+  // See: https://github.com/mysticatea/eslint-plugin-node/blob/master/docs/rules/shebang.md
+  'node/shebang': 'off',
 
   // See: https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-extraneous-dependencies.md
   'import/no-extraneous-dependencies': [


### PR DESCRIPTION
it assumes you only ever want `#!/usr/bin/env node` on things in your
`bin` section, but people might want random unexported things in
`./scripts/` e.g.


---
_This PR was started by: [git wf pr](https://github.com/groupon/git-workflow/releases/tag/v1.0.3)_