### PR TITLE
upgrade to prettier2

### DIFF
--- a/lib/rules/opinions.js
+++ b/lib/rules/opinions.js
@@ -40,13 +40,7 @@
  */
 module.exports = {
   // See: https://github.com/prettier/eslint-plugin-prettier
-  'prettier/prettier': [
-    'error',
-    {
-      singleQuote: true,
-      trailingComma: 'es5',
-    },
-  ],
+  'prettier/prettier': ['error', { singleQuote: true, arrowParens: 'avoid' }],
 
   // See: https://eslint.org/docs/rules/lines-around-directive
   'lines-around-directive': ['error', 'always'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -3117,9 +3117,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
-      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.2.tgz",
+      "integrity": "sha512-5xJQIPT8BraI7ZnaDwSbu5zLrB6vvi8hVV58yHQ+QK64qrY40dULy0HSRlQ2/2IdzeBpjhDkqdcFBnFeDEMVdg==",
       "dev": true
     },
     "prettier-linter-helpers": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "eslint-plugin-node": ">=10.0.0",
     "eslint-plugin-prettier": ">=3.1.0",
     "eslint": "^6",
-    "prettier": ">=1.18.2"
+    "prettier": ">=2.0.0"
   },
   "dependencies": {},
   "devDependencies": {
@@ -52,7 +52,7 @@
     "mocha": "^7.0.1",
     "nlm": "^3.6.3",
     "npm-run-all": "^4.1.5",
-    "prettier": "^1.19.1"
+    "prettier": "^2.0.2"
   },
   "author": {
     "name": "Jan Krems",


### PR DESCRIPTION
* requires prettier 2.x peer dep
* marked breaking because of number of style changes
* chained methods now often on one line
* arrowParens has old defaults of 'avoid' - we like the old setting
    better for now

See: https://prettier.io/blog/2020/03/21/2.0.0.html

BREAKING CHANGE: requires prettier 2.x peerDep and will result in a
lot of style changes around chained method invocations


---
_This PR was started by: [git wf pr](https://github.com/groupon/git-workflow/releases/tag/v1.0.4)_