### PR TITLE
Add no-return-await rule warning level to conventions

### DIFF
--- a/lib/rules/conventions.js
+++ b/lib/rules/conventions.js
@@ -52,6 +52,9 @@ module.exports = {
   // See: https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-dynamic-require.md
   'import/no-dynamic-require': 'warn', // pending: Can't be auto-fixed
 
+  // See: https://eslint.org/docs/rules/no-return-await
+  'no-return-await': 'warn', // pending: Can't be auto-fixed
+
   // See: https://eslint.org/docs/rules/no-regex-spaces
   'no-regex-spaces': 'error',
 


### PR DESCRIPTION
This rule cannot be auto-fixed by ESLint yet, adding to conventions.