### PR TITLE
lower peerDep req for typescript-eslint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,14 +27,15 @@
         "node": ">=10.13"
       },
       "peerDependencies": {
-        "@typescript-eslint/eslint-plugin": ">=5.2.0",
-        "@typescript-eslint/parser": ">=5.2.0",
+        "@typescript-eslint/eslint-plugin": ">=4.20.0",
+        "@typescript-eslint/parser": ">=4.20.0",
         "eslint": "^7.28.0",
         "eslint-plugin-import": ">=2.18.2",
         "eslint-plugin-mocha": ">=6.1.0",
         "eslint-plugin-node": ">=11.0.0",
         "eslint-plugin-prettier": ">=4.0.0",
-        "prettier": ">=2.0.0"
+        "prettier": ">=2.0.0",
+        "typescript": ">=4.0.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
     }
   },
   "peerDependencies": {
-    "@typescript-eslint/eslint-plugin": ">=5.2.0",
-    "@typescript-eslint/parser": ">=5.2.0",
+    "@typescript-eslint/eslint-plugin": ">=4.20.0",
+    "@typescript-eslint/parser": ">=4.20.0",
     "eslint": "^7.28.0",
     "eslint-plugin-import": ">=2.18.2",
     "eslint-plugin-mocha": ">=6.1.0",


### PR DESCRIPTION
...we don't actually need 5.x yet, as we aren't yet requiring eslint 8



---
_This PR was started by: [git wf pr](https://github.com/groupon/git-workflow/releases/tag/v1.3.4)_