### PR TITLE
always use latest ecmaVersion

### DIFF
--- a/lib/basics.js
+++ b/lib/basics.js
@@ -42,4 +42,7 @@ module.exports = {
   },
   extends: ['plugin:node/recommended'],
   plugins: ['import', 'mocha', 'node', 'prettier'],
+  parserOptions: {
+    ecmaVersion: 'latest',
+  },
 };


### PR DESCRIPTION
We're happy for eslint to fail on rules, but there's no reason for it to
fail to parse.  This will e.g. get us support for `?.` the optional
chaining operator.



---
_This PR was started by: [git wf pr](https://github.com/groupon/git-workflow/releases/tag/v1.3.4)_