### PR TITLE
rollback ecmaVersion to 2020

### DIFF
--- a/lib/basics.js
+++ b/lib/basics.js
@@ -43,6 +43,6 @@ module.exports = {
   extends: ['plugin:node/recommended'],
   plugins: ['import', 'mocha', 'node', 'prettier'],
   parserOptions: {
-    ecmaVersion: 'latest',
+    ecmaVersion: 2020,
   },
 };


### PR DESCRIPTION
..."latest" isn't available until acorn 8 which isn't available until
eslint 8



---
_This PR was started by: [git wf pr](https://github.com/groupon/git-workflow/releases/tag/v1.3.4)_